### PR TITLE
alter sentiment score column to REAL and rename column names

### DIFF
--- a/brossessment/models.py
+++ b/brossessment/models.py
@@ -9,7 +9,7 @@ postgres_db = PostgresqlDatabase(POSTGRES_DB, host=POSTGRES_HOST, port=POSTGRES_
 
 class User(Model):
     user_id = BigIntegerField(primary_key=True)
-    average_sentiment_score = DecimalField(decimal_places=3)
+    average_sentiment_score = FloatField()
 
     class Meta:
         database = postgres_db
@@ -18,7 +18,7 @@ class User(Model):
 
 class Class(Model):
     class_id = BigIntegerField(primary_key=True)
-    average_sentiment_score = DecimalField(decimal_places=3)
+    average_sentiment_score = FloatField()
 
     class Meta:
         database = postgres_db
@@ -30,7 +30,9 @@ class Post(Model):
     class_id = ForeignKeyField(Class, null=True)
     user_id = ForeignKeyField(User, null=True)
     builds_on = ForeignKeyField('self', related_name='builds_on')
-    average_sentiment_score = DecimalField(decimal_places=3)
+    google_sentiment_score = FloatField()
+    google_sentiment_magnitude = FloatField()
+    textblob_sentiment_score = FloatField()
     title = TextField()
     content = TextField()
     topic_id = BigIntegerField()

--- a/sql/_4_alter_sentiment_score.sql
+++ b/sql/_4_alter_sentiment_score.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts ADD COLUMN google_sentiment_magnitude REAL;
+ALTER TABLE posts RENAME COLUMN sentiment_score TO google_sentiment_score;
+ALTER TABLE posts ALTER COLUMN google_sentiment_score TYPE REAL;
+ALTER TABLE posts ADD COLUMN textblob_sentiment_score REAL;
+ALTER TABLE users ALTER COLUMN average_sentiment_score TYPE REAL;
+ALTER TABLE classes ALTER COLUMN average_sentiment_score TYPE REAL;


### PR DESCRIPTION
- changed sentiment score type is now `REAL` instead of `NUMERIC`
- added `google_sentiment_magnitude` and `textblob_sentiment_score`
- rename `sentiment_score` to `google_sentiment_score`